### PR TITLE
[build] Add support for cross-compiling from Windows

### DIFF
--- a/makefile
+++ b/makefile
@@ -4,7 +4,7 @@ TCP_C_DIR = $(MTCP_DIR)\TCPLIB
 COMMON_H_DIR = $(MTCP_DIR)\INCLUDE
 
 MEMORY_MODEL = -ms
-CFLAGS = -0 $(MEMORY_MODEL) -DCFG_H="mtcpcomp.cfg" -oh -ok -os -s -oa -ei -zp2 -zpw -we
+CFLAGS = -0 $(MEMORY_MODEL) -DCFG_H="mtcpcomp.cfg" -oh -ok -os -s -oa -ei -zp2 -zpw -we -bt=DOS
 CFLAGS += -i=$(TCP_H_DIR) -i=$(COMMON_H_DIR)
 
 MTCP_OBJS = packet.obj dns.obj arp.obj eth.obj ip.obj udp.obj utils.obj timer.obj ipasm.obj trace.obj


### PR DESCRIPTION
OpenWatcom defaults to building for the host OS.  Adding -bt=DOS
allows the compiler to define the DOS specific macros allowing
for a successful build.